### PR TITLE
Made Swift 3.0 compatible by removing post decrement and c-style

### DIFF
--- a/test.swift
+++ b/test.swift
@@ -6,7 +6,7 @@ import Cocoa
 
 func forEachLoopMaxInteger(max: Int64) -> Int64 {
 	var sum : Int64 = 0
-	for (var n = max; n > 0;  n--) {
+	for n in 1...max {
 		let _ = n / 17
 		sum = sum + n 
 	}


### PR DESCRIPTION
According to [Swift Roadmap](https://github.com/apple/swift-evolution/blob/master/README.md#accepted-proposals-for-swift-30) and accepted proposals [0004](https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md) and [0007](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)

Essentially the huge speed performance is gone with this implementation.
Now it takes about 10 times longer which hopefully will be improved when 3.0 is released…

[I] 12:09@25.Jan/D/S/Tests|feature/swift3✓ ➤ head -2 ../first | tail -1; head -2 ../second | tail -1; 
Swift: 215ms
Swift: 2147ms

So it looks more like this on my machine, ordered by speed:
1. JavaScript: 506ms
2. Java: 561ms
3. C: 1037ms
4. C++: 1097ms
5. **Objective-C: 1130**
6. Perl: 19696ms
7. **Swift: 2147ms**
8. Python: 8048ms
9. Ruby: 8656ms

Not that good, since your approach did lead to results similar to the ones you measured…
