### PR TITLE
fix: for more accuracy Date.now replaced with process.uptime

### DIFF
--- a/test.js
+++ b/test.js
@@ -8,9 +8,9 @@ function test(max) {
 	return sum;
 }
 
-var start = new Date().getTime();
+var start = process.uptime();
 test(100000000);
-var end = new Date().getTime();
+var end = process.uptime();
 var time = end - start;
 
-process.stdout.write("JavaScript: " + time + "ms\n");
+process.stdout.write("JavaScript: " + (time * 1000) + "ms\n");


### PR DESCRIPTION
We always usign `process.uptime()` becuase `Date.now()` has very huge process